### PR TITLE
Fix compiling under ARM arch

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -40,7 +40,7 @@ impl RawKey {
 
     fn query_keystate(&self, key: u32) -> bool {
         unsafe {
-            let keymap: *mut i8 = [0; 32].as_mut_ptr();
+            let keymap = [0; 32].as_mut_ptr();
             xlib::XQueryKeymap(self.display, keymap);
             for (ix, byte) in slice::from_raw_parts(keymap, 32).iter().enumerate() {
                 for bit in 0_u8..8_u8 {


### PR DESCRIPTION
`i8` is equal to `c_char` on `x86`, it is different on other platforms, for example, `c_char` is equal to `u8` on `arm` arch. Thus we need to use `std::os::raw::c_char` \ `libc::c_char` or we let rust infer the type.

Additional note: the repository doesn't have git version tags.